### PR TITLE
Handle http client errors correctly

### DIFF
--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -3,6 +3,7 @@ package filestore
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -74,11 +75,11 @@ func (fs *S3FileStore) StoreFile(p *StoreFileParams) (out *StoreFileOutput, err 
 		Key:    &p.id,
 	})
 
-	url, _, err := putObj.PresignRequest(15 * time.Minute) // headers is nil in this case
+	presignedurl, _, err := putObj.PresignRequest(15 * time.Minute) // headers is nil in this case
 	if err != nil {
 		return nil, err // may want to wrap error here, not sure how to test
 	}
-	req, err := http.NewRequest("PUT", url, p.data)
+	req, err := http.NewRequest("PUT", presignedurl, p.data)
 	if err != nil {
 		return nil, err // may want to wrap error here, not sure now to test
 	}
@@ -88,7 +89,8 @@ func (fs *S3FileStore) StoreFile(p *StoreFileParams) (out *StoreFileOutput, err 
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err // may want to wrap error here, not sure how to test
+		// don't expose the presigned url in the returned error
+		return nil, err.(*url.Error).Err
 	}
 	stored, err := time.Parse(time.RFC1123, resp.Header.Get("Date"))
 	if err != nil {

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -90,7 +90,8 @@ func (fs *S3FileStore) StoreFile(p *StoreFileParams) (out *StoreFileOutput, err 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		// don't expose the presigned url in the returned error
-		return nil, err.(*url.Error).Err
+		// The wrapped error has weird behavior that I don't understand, so rewrap in a std err
+		return nil, errors.New(err.(*url.Error).Err.Error())
 	}
 	stored, err := time.Parse(time.RFC1123, resp.Header.Get("Date"))
 	if err != nil {

--- a/filestore/s3_test.go
+++ b/filestore/s3_test.go
@@ -151,8 +151,6 @@ func (t *TestSuite) TestStoreWithIncorrectSize() {
 	if res != nil {
 		t.Fail("returned object is not nil")
 	}
-	// I don't understand why the below doesn't work,
-	// t.Equal(errors.New("http: ContentLength=11 with Body length 12"), err, "incorrect error")
 	// might want a different error message here
-	t.Equal("http: ContentLength=11 with Body length 12", err.Error(), "incorrect error")
+	t.Equal(errors.New("http: ContentLength=11 with Body length 12"), err, "incorrect error")
 }

--- a/filestore/s3_test.go
+++ b/filestore/s3_test.go
@@ -93,7 +93,7 @@ func (t *TestSuite) TestConstructWithExistingBucket() {
 	t.Equal(fstore.GetBucket(), bucket, "incorrect bucket")
 }
 
-func (t *TestSuite) TestGetAndPut() {
+func (t *TestSuite) TestStoreAndGet() {
 	mclient := t.minio.CreateS3Client()
 	fstore, err := NewS3FileStore(mclient, "mybucket")
 	if err != nil {
@@ -129,4 +129,30 @@ func (t *TestSuite) TestGetAndPut() {
 	t.Equal(expected, res, "unexpected output")
 
 	//TODO get file and check contents
+}
+
+func (t *TestSuite) TestStoreWithIncorrectSize() {
+	mclient := t.minio.CreateS3Client()
+	fstore, err := NewS3FileStore(mclient, "mybucket")
+	if err != nil {
+		t.Fail(err.Error())
+	}
+	p, err := NewStoreFileParams(
+		"myid",
+		11,
+		strings.NewReader("012345678910"),
+		Format("json"),
+		FileName("fn"),
+	)
+	if err != nil {
+		t.Fail(err.Error())
+	}
+	res, err := fstore.StoreFile(p)
+	if res != nil {
+		t.Fail("returned object is not nil")
+	}
+	// I don't understand why the below doesn't work,
+	// t.Equal(errors.New("http: ContentLength=11 with Body length 12"), err, "incorrect error")
+	// might want a different error message here
+	t.Equal("http: ContentLength=11 with Body length 12", err.Error(), "incorrect error")
 }


### PR DESCRIPTION
Definitely don't want to return the presigned url in the error string

Adds a test with an incorrect data size