### PR TITLE
Attempt to fix time issues on Store/Get file test

### DIFF
--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -11,11 +11,13 @@ mongodb-database = blobstore
 #mongodb-user = [username]
 #mongodb-pwd = [password]
 
-# S3 API parameters. All are required other than region.
+# S3 API parameters. All are required other than region and disable-ssl.
+# disable-ssl treats any value other than 'true' as false.
 s3-host: localhost:9000
 s3-bucket: blobstore
 s3-access-key: [access key goes here]
 s3-access-secret: [access secret goes here]
+#s3-disable-ssl: false
 #s3-region: us-west-1
 
 # KBase auth server parameters.


### PR DESCRIPTION
For storing the file, the returned time is parsed from the headers returned by the http request, which apparently is not always identical to the time returned by the S3 client. Use the S3 client to get the time after storing the file.