### PR TITLE
Take a another crack a fixing failing tests

### DIFF
--- a/filestore/s3_test.go
+++ b/filestore/s3_test.go
@@ -125,7 +125,10 @@ func (t *TestSuite) storeAndGet(filename string, format string) {
 	res, _ := fstore.StoreFile(p)
 
 	stored := res.Stored
-	testhelpers.AssertCloseToNow1S(t.T(), stored)
+	// sometimes a 1 sec delta fails. I'm guessing that S3 returns a time that is rounded
+	// down, and so if the time is very close to the next second, at the time the test occurs
+	// it's flipped over to the next second and the test fails.
+	testhelpers.AssertCloseToNow(t.T(), stored, 2 * time.Second)
 	expected := &StoreFileOutput{
 		ID:       "myid",
 		Size:     12,
@@ -265,7 +268,10 @@ func (t *TestSuite) TestGetWithoutMetaData() {
 		t.Fail(err.Error())
 	}
 	defer obj.Data.Close()
-	testhelpers.AssertCloseToNow1S(t.T(), obj.Stored)
+	// sometimes a 1 sec delta fails. I'm guessing that S3 returns a time that is rounded
+	// down, and so if the time is very close to the next second, at the time the test occurs
+	// it's flipped over to the next second and the test fails.
+	testhelpers.AssertCloseToNow(t.T(), obj.Stored, 2 * time.Second)
 	
 	b, _ := ioutil.ReadAll(obj.Data)
 	t.Equal("012345678910", string(b), "incorrect object contents")
@@ -379,7 +385,10 @@ func (t *TestSuite) copy(filename string, format string) {
 	}
 
 	obj, _ := fstore.GetFile("  myid3   ")
-	testhelpers.AssertCloseToNow1S(t.T(), obj.Stored)
+	// sometimes a 1 sec delta fails. I'm guessing that S3 returns a time that is rounded
+	// down, and so if the time is very close to the next second, at the time the test occurs
+	// it's flipped over to the next second and the test fails.
+	testhelpers.AssertCloseToNow(t.T(), obj.Stored, 2 * time.Second)
 	defer obj.Data.Close()
 	b, _ := ioutil.ReadAll(obj.Data)
 	t.Equal("012345678910", string(b), "incorrect object contents")

--- a/test/testhelpers/helpers.go
+++ b/test/testhelpers/helpers.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// AssertCloseToNow1S asserts that the given time is within one second of the present time.
-func AssertCloseToNow1S(t *testing.T, tme time.Time) {
+// AssertCloseToNow asserts that the given time is within the given duration of the present time.
+func AssertCloseToNow(t *testing.T, tme time.Time, dur time.Duration) {
 	et := time.Now()
 
 	// testify has comparisons in the works but not released as of this writng
-	assert.True(t, et.Add(time.Second*-1).Before(tme),
+	assert.True(t, et.Add(-1*dur).Before(tme),
 		fmt.Sprintf("time %v earlier than expected %v", tme, et))
-	assert.True(t, et.Add(time.Second*1).After(tme),
+	assert.True(t, et.Add(dur).After(tme),
 		fmt.Sprintf("time %v later than expected %v", tme, et))
 }
 


### PR DESCRIPTION
Tests that check that a time is close to now +/- 1 sec sometimes fail.

I think this is because S3 always rounds the time down, and so if the time is close to the next second, it gets rounded down, and then if the time flips over to the next second before the test, the test fails. Usually the test time when it fails is just barely over the second mark.