### PR TITLE
 Add acl returns to core code & check public auth 

### DIFF
--- a/service/integration_test.go
+++ b/service/integration_test.go
@@ -398,7 +398,6 @@ func (t *TestSuite) TestStoreAndGetWithFilename() {
 	}
 	t.checkNode(id, &t.noRole, 380, expected2)
 
-	// TODO TEST check download header
 	path1 := "/node/" + id
 	path2 := path1 + "/"
 	t.checkFile(t.url + path1 + "?download", path1, &t.noRole, 9, "myfile", []byte("foobarbaz"))

--- a/service/server.go
+++ b/service/server.go
@@ -80,7 +80,7 @@ func New(cfg *config.Config, sconf ServerStaticConf) (*Server, error) {
 	//TODO ACLs handle node acls (verbosity)
 	// TODO ACLS chown node
 	// TODO ACLS public read
-	// TODO TEST content-type and content-length headers
+	// TODO DOCKER and docker-compose-up
 	return s, nil
 }
 


### PR DESCRIPTION
Core can now return public nodes although there's no way to set them as such