### PR TITLE
Refactor ACL handling

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -80,7 +80,7 @@ func TestStoreBasic(t *testing.T) {
 		Filename: "",
 		Format: "",
 		Owner: User{userid, "username"},
-		Readers: &[]User{},
+		Readers: &[]User{User{userid, "username"}},
 		Public: false,
 	}
 	assert.Equal(t, expected, bnode, "incorrect node")
@@ -139,7 +139,7 @@ func TestStoreWithFilenameAndFormat(t *testing.T) {
 		Filename: "myfile",
 		Format: "excel",
 		Owner: User{userid, "username"},
-		Readers: &[]User{},
+		Readers: &[]User{User{userid, "username"}},
 		Public: false,
 	}
 	assert.Equal(t, expected, bnode, "incorrect node")
@@ -297,7 +297,7 @@ func TestGetAsOwner(t *testing.T) {
 		Filename: "fn",
 		Format: "json",
 		Owner: User{userid, "username"},
-		Readers: &[]User{},
+		Readers: &[]User{User{userid, "username"}},
 		Public: false,
 	}
 	assert.Equal(t, expected, bnode, "incorrect node")
@@ -337,7 +337,7 @@ func TestGetAsReader(t *testing.T) {
 		Filename: "",
 		Format: "",
 		Owner: User{nid, "username"},
-		Readers: &[]User{User{oid, "other"}, User{rid, "reader"}},
+		Readers: &[]User{User{nid, "username"}, User{oid, "other"}, User{rid, "reader"}},
 		Public: false,
 	}
 	assert.Equal(t, expected, bnode, "incorrect node")
@@ -375,7 +375,7 @@ func TestGetAsAdmin(t *testing.T) {
 		Filename: "",
 		Format: "",
 		Owner: User{nid, "username"},
-		Readers: &[]User{User{oid, "other"}},
+		Readers: &[]User{User{nid, "username"}, User{oid, "other"}},
 		Public: false,
 	}
 	assert.Equal(t, expected, bnode, "incorrect node")
@@ -409,7 +409,7 @@ func TestGetPublic(t *testing.T) {
 		Filename: "",
 		Format: "",
 		Owner: User{nid, "username"},
-		Readers: &[]User{},
+		Readers: &[]User{User{nid, "username"}},
 		Public: true,
 	}
 	bnode, err := bs.Get(nil, uid)

--- a/nodestore/interface_test.go
+++ b/nodestore/interface_test.go
@@ -36,7 +36,7 @@ func TestNewNodeMin(t *testing.T) {
 		)
 	assert.Nil(t, err, "unexpected error")
 
-	readers := []User(nil)
+	readers := []User{*owner}
 	assert.Equal(t, id, n.GetID(), "incorrect ID")
 	assert.Equal(t, *owner, n.GetOwner(), "incorrect owner")
 	assert.Equal(t, int64(67), n.GetSize(), "incorrect size")
@@ -63,11 +63,11 @@ func TestNewNodeFull(t *testing.T) {
 		Format("    txt   "),
 		FileName("   file.txt   "),
 		Public(true),
-		Reader(*r1), Reader(*r2),
+		Reader(*r1), Reader(*r2), Reader(*r1), Reader(*owner), // test duplicates are removed
 		)
 	assert.Nil(t, err, "unexpected error")
 
-	readers := []User{*r1, *r2}
+	readers := []User{*owner, *r1, *r2}
 	assert.Equal(t, id, n.GetID(), "incorrect ID")
 	assert.Equal(t, *owner, n.GetOwner(), "incorrect owner")
 	assert.Equal(t, int64(67), n.GetSize(), "incorrect size")
@@ -93,7 +93,7 @@ func TestNodeImmutable(t *testing.T) {
 		)
 	
 	// this test isn't really failsafe since it's not clear when append returns a new slice
-	readers := []User{*r1}
+	readers := []User{*owner, *r1}
 	_ = append(*n.GetReaders(), *r2)
 	assert.Equal(t, &readers, n.GetReaders(), "incorrect readers")
 }

--- a/nodestore/mongostore_test.go
+++ b/nodestore/mongostore_test.go
@@ -463,6 +463,27 @@ func (t *TestSuite) TestAddOwnerAsReader() {
 	t.Equal(expected, node, "incorrect node")
 }
 
+func (t *TestSuite) TestRemoveOwnerAsReader() {
+	// expect no change to the node and no error
+	mns, err := NewMongoNodeStore(t.client.Database(testDB))
+	t.Nil(err, "expected no error")
+	own, _ := NewUser(uuid.New(), "owner")
+	nid := uuid.New()
+	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+
+	err = mns.StoreNode(n)
+	t.Nil(err, "expected no error")
+
+	err = mns.RemoveReader(nid, *own)
+	t.Nil(err, "expected no error")
+
+	node, err := mns.GetNode(nid)
+	t.Nil(err, "expected no error")
+
+	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", node.GetStoredTime())
+	t.Equal(expected, node, "incorrect node")
+}
+
 func (t *TestSuite) TestAddReaderTwice() {
 	// expect no change to the node and no error
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
@@ -553,7 +574,7 @@ func (t *TestSuite) TestRemoveReaderFailNoNode() {
 }
 
 func (t *TestSuite) TestChangeOwner() {
-	// tests that user is removed from the read acl if made owner
+	// tests that user is added to the read acl if made owner
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
@@ -564,14 +585,12 @@ func (t *TestSuite) TestChangeOwner() {
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
 
-	err = mns.AddReader(nid, *newown)
-	t.Nil(err, "expected no error")
 	node, err := mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 
 	tme := node.GetStoredTime()
 	
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme, Reader(*newown))
+	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
 	t.Equal(expected, node, "incorrect node")
 
 	// test that changing to the current owner has no effect
@@ -586,7 +605,7 @@ func (t *TestSuite) TestChangeOwner() {
 	node, err = mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 	
-	expected, _= NewNode(nid, *newown, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	expected, _= NewNode(nid, *newown, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme, Reader(*own))
 	t.Equal(expected, node, "incorrect node")
 }
 

--- a/service/server.go
+++ b/service/server.go
@@ -483,7 +483,7 @@ func fromNodeToACL(node *core.BlobNode, verbose bool) map[string]interface{} {
 		"owner":  o,
 		"delete": []interface{}{o},
 		"write":  []interface{}{o},
-		"read":   toUsers(o, node.Readers, verbose),
+		"read":   toUsers(node.Readers, verbose),
 		"public": map[string]bool{
 			"write":  false,
 			"delete": false,
@@ -492,8 +492,8 @@ func fromNodeToACL(node *core.BlobNode, verbose bool) map[string]interface{} {
 	}
 }
 
-func toUsers(owner interface{}, users *[]core.User, verbose bool) []interface{} {
-	ulist := &[]interface{}{owner}
+func toUsers(users *[]core.User, verbose bool) []interface{} {
+	ulist := &[]interface{}{}
 	for _, u := range *users {
 		*ulist = append(*ulist, toUser(u, verbose))
 	}


### PR DESCRIPTION
Realized chown was going to be impossible to implement with mongo restrictions
on changing a field twice in one query. Now the owner is added to the read acl
immediately and stays there after a chown.