### PR TITLE
Make tests pass with latest versions of minio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: go
 go: "1.12"
 
 env: 
-  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 MINIO=2019-04-23T23-50-36Z WIRED_TIGER=false
-  - MONGODB_VER=mongodb-linux-x86_64-3.6.8  MINIO=2019-04-23T23-50-36Z WIRED_TIGER=false
-  - MONGODB_VER=mongodb-linux-x86_64-3.6.8  MINIO=2019-04-23T23-50-36Z WIRED_TIGER=true
+  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 MINIO=2019-05-23T00-29-34Z WIRED_TIGER=false
+  - MONGODB_VER=mongodb-linux-x86_64-3.6.8  MINIO=2019-05-23T00-29-34Z WIRED_TIGER=false
+  - MONGODB_VER=mongodb-linux-x86_64-3.6.8  MINIO=2019-05-23T00-29-34Z WIRED_TIGER=true
 
 install:
   - export GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ not supported; only those required for the KBase codebase are included.
 
 # Requirements:
 * go 1.12
-* An S3 compatible storage system. The Blobstore is tested with Minio version 2019-04-23T23-50-36Z.
+* An S3 compatible storage system. The Blobstore is tested with Minio version 2019-05-23T00-29-34Z.
+  * If Minio is used, at least version 2019-05-14T23-57-45Z is required.
 * MongoDB 2.6+
 
 # Testing

--- a/test/miniocontroller/controller.go
+++ b/test/miniocontroller/controller.go
@@ -60,6 +60,7 @@ func New(p Params) (*Controller, error) {
 	cmd := exec.Command(
 		p.ExecutablePath,
 		"server",
+		"--compat",
 		"--address", "localhost:"+strconv.Itoa(port),
 		ddir)
 	cmd.Env = append(


### PR DESCRIPTION
Minio 2019-05-14T23-57-45Z contains a backwards incompatible change that
breaks S3 compatibility, unless run with --compat