### PR TITLE
Add copy node to server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ cannot be relative.
 
 Mocks are generated with https://github.com/vektra/mockery v1.0.0.
 
+
+# Known issues
+
+* Providing a `Content-Type` header of `multipart/form-data; boundary=` when trying to copy a node
+  will result in the `go` function that parses multipart data asserting that the http body is
+  not form data, and so the body will be processed as a file upload. This is an issue in the
+  `go` `mime` library.
+
 # TODO
 * HTTP2 support
 

--- a/service/integration_test.go
+++ b/service/integration_test.go
@@ -986,6 +986,8 @@ func (t *TestSuite) TestCopyNodeFail() {
 			"Method Not Allowed", 79},
 		testcase{"POST", id + "a", "oauth " + t.kBaseAdmin.token, &t.kBaseAdmin.user, 400,
 			"Invalid copy_data: invalid UUID length: 37", 103},
+		testcase{"POST", id + "aaaaa", "oauth " + t.kBaseAdmin.token, &t.kBaseAdmin.user, 400,
+			"Invalid copy_data: invalid UUID length: 40", 103},
 		testcase{"POST", id[:35], "oauth " + t.kBaseAdmin.token, &t.kBaseAdmin.user, 400,
 			"Invalid copy_data: invalid UUID length: 35", 103},
 		testcase{"POST", string(badid2), "oauth " + t.kBaseAdmin.token, &t.kBaseAdmin.user, 400,


### PR DESCRIPTION
Found what appears to be a bug in the go mime library such that
parsing a multipart form can sometimes return that it's not a
MPF when it really is.