### PR TITLE
Move auth cache into its own package

### DIFF
--- a/auth/cache/cache.go
+++ b/auth/cache/cache.go
@@ -1,6 +1,7 @@
-package auth
+package cache
 
 import (
+	"github.com/kbase/blobstore/auth"
 	gcache "github.com/patrickmn/go-cache"
 )
 
@@ -9,17 +10,17 @@ import (
 // Cache caches auth service data from a provider.
 type Cache struct {
 	cache *gcache.Cache
-	prov  Provider
+	prov  auth.Provider
 }
 
 // NewCache creates a new auth cache.
-func NewCache(prov Provider) *Cache {
+func NewCache(prov auth.Provider) *Cache {
 	return &Cache{nil, prov}
 }
 
 // GetUser gets a user given a token.
 // Returns InvalidToken error.
-func (c *Cache) GetUser(token string) (*User, error) {
+func (c *Cache) GetUser(token string) (*auth.User, error) {
 	u, _, _, err := c.prov.GetUser(token)
 	if err != nil {
 		return nil, err

--- a/service/build.go
+++ b/service/build.go
@@ -19,6 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/kbase/blobstore/auth"
+	authcache "github.com/kbase/blobstore/auth/cache"
 	"github.com/kbase/blobstore/config"
 	"github.com/minio/minio-go"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -28,8 +29,8 @@ import (
 
 // Dependencies contain the built dependencies of the blobstore service.
 type Dependencies struct {
-	AuthCache    *auth.Cache
-	BlobStore    *core.BlobStore
+	AuthCache *authcache.Cache
+	BlobStore *core.BlobStore
 }
 
 // ConstructDependencies builds the blobstore dependencies from a configuration.
@@ -93,7 +94,7 @@ func buildNodeStore(cfg *config.Config) (nodestore.NodeStore, error) {
 	return nodestore.NewMongoNodeStore(db)
 }
 
-func buildAuth(cfg *config.Config) (*auth.Cache, error) {
+func buildAuth(cfg *config.Config) (*authcache.Cache, error) {
 	roles := []func(*auth.KBaseProvider) error{}
 	for _, r := range *cfg.AuthAdminRoles {
 		roles = append(roles, auth.AdminRole(r))
@@ -102,5 +103,5 @@ func buildAuth(cfg *config.Config) (*auth.Cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	return auth.NewCache(prov), nil
+	return authcache.NewCache(prov), nil
 }

--- a/service/server.go
+++ b/service/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	authcache "github.com/kbase/blobstore/auth/cache"
 	"github.com/kbase/blobstore/core"
 
 	"github.com/kbase/blobstore/auth"
@@ -58,7 +59,7 @@ type ServerStaticConf struct {
 type Server struct {
 	mux        *mux.Router
 	staticconf ServerStaticConf
-	auth       *auth.Cache
+	auth       *authcache.Cache
 	store      *core.BlobStore
 }
 


### PR DESCRIPTION
Was getting an import cycle in test mocks as the mocks imported auth which
then imported the mocks in the test file