### PR TITLE
Check for valid MD5s

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -9,12 +9,12 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/kbase/blobstore/auth"
+	"github.com/kbase/blobstore/core/values"
 
 	"github.com/kbase/blobstore/filestore"
 	"github.com/kbase/blobstore/nodestore"
 )
 
-// TODO * MD5 make and use md5 class to catch s3hashes.
 // TODO * INPUT limits on string length.
 
 // User is a user that may own or read Nodes.
@@ -29,7 +29,7 @@ type User struct {
 type BlobNode struct {
 	ID       uuid.UUID
 	Size     int64
-	MD5      string
+	MD5      values.MD5
 	Stored   time.Time
 	Filename string
 	Format   string

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/kbase/blobstore/core/values"
 	"io/ioutil"
 	"errors"
 	"github.com/stretchr/testify/assert"
@@ -50,17 +51,18 @@ func TestStoreBasic(t *testing.T) {
 		12,
 		strings.NewReader("012345678910"))
 	tme := time.Now()
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	sto := filestore.FileInfo{
 		ID: "41/22/a8/4122a860-ce69-45cc-9d5d-3d2585fbfd74",
 		Size: 12,
 		Format: "",
 		Filename: "",
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 	}
 	fsmock.On("StoreFile", p).Return(&sto, nil)
 
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme)
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme)
 	nsmock.On("StoreNode", node).Return(nil)
 	auser, _ := auth.NewUser("username", false)
 
@@ -75,7 +77,7 @@ func TestStoreBasic(t *testing.T) {
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "",
 		Format: "",
@@ -100,6 +102,7 @@ func TestStoreWithFilenameAndFormat(t *testing.T) {
 	uidmock.On("GetUUID").Return(uid)
 	nsmock.On("GetUser", "username").Return(nuser, nil)
 
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	p, _ := filestore.NewStoreFileParams(
 		"41/22/a8/4122a860-ce69-45cc-9d5d-3d2585fbfd74",
 		12,
@@ -112,13 +115,13 @@ func TestStoreWithFilenameAndFormat(t *testing.T) {
 		Size: 12,
 		Format: "myfile",
 		Filename: "excel",
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 	}
 	fsmock.On("StoreFile", p).Return(&sto, nil)
 
 	node, _ := nodestore.NewNode(
-		uid, *nuser, 12, "fakemd5", tme, nodestore.FileName("myfile"), nodestore.Format("excel"))
+		uid, *nuser, 12, *md5, tme, nodestore.FileName("myfile"), nodestore.Format("excel"))
 	nsmock.On("StoreNode", node).Return(nil)
 
 	auser, _ := auth.NewUser("username", false)
@@ -134,7 +137,7 @@ func TestStoreWithFilenameAndFormat(t *testing.T) {
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "myfile",
 		Format: "excel",
@@ -241,17 +244,18 @@ func TestStoreFailStoreNode(t *testing.T) {
 		12,
 		strings.NewReader("012345678910"))
 	tme := time.Now()
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	sto := filestore.FileInfo{
 		ID: "/41/22/a8/4122a860-ce69-45cc-9d5d-3d2585fbfd74",
 		Size: 12,
 		Format: "",
 		Filename: "",
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 	}
 	fsmock.On("StoreFile", p).Return(&sto, nil)
 
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme)
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme)
 	nsmock.On("StoreNode", node).Return(errors.New("the loveliest of them all"))
 
 	auser, _ := auth.NewUser("username", false)
@@ -282,8 +286,9 @@ func TestGetAsOwner(t *testing.T) {
 	nsmock.On("GetUser", "un").Return(nuser, nil)
 
 	tme := time.Now()
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	node, _ := nodestore.NewNode(
-		uid, *nuser, 12, "fakemd5", tme, nodestore.FileName("fn"), nodestore.Format("json"))
+		uid, *nuser, 12, *md5, tme, nodestore.FileName("fn"), nodestore.Format("json"))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
@@ -292,7 +297,7 @@ func TestGetAsOwner(t *testing.T) {
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "fn",
 		Format: "json",
@@ -322,8 +327,9 @@ func TestGetAsReader(t *testing.T) {
 	nsmock.On("GetUser", "reader").Return(ruser, nil)
 
 	tme := time.Now()
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	node, _ := nodestore.NewNode(
-		uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ouser), nodestore.Reader(*ruser))
+		uid, *nuser, 12, *md5, tme, nodestore.Reader(*ouser), nodestore.Reader(*ruser))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
@@ -332,7 +338,7 @@ func TestGetAsReader(t *testing.T) {
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "",
 		Format: "",
@@ -361,7 +367,8 @@ func TestGetAsAdmin(t *testing.T) {
 	nsmock.On("GetUser", "reader").Return(ruser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ouser))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Reader(*ouser))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
@@ -370,7 +377,7 @@ func TestGetAsAdmin(t *testing.T) {
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "",
 		Format: "",
@@ -397,14 +404,15 @@ func TestGetPublic(t *testing.T) {
 	nsmock.On("GetUser", "reader").Return(ruser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Public(true))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Public(true))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 	
 	expected := &BlobNode {
 		ID: uid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "",
 		Format: "",
@@ -481,7 +489,8 @@ func TestGetFailUnauthorized(t *testing.T) {
 	nsmock.On("GetUser", "other").Return(ouser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ruser))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Reader(*ruser))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
@@ -511,16 +520,18 @@ func TestGetFileAsOwner(t *testing.T) {
 	nsmock.On("GetUser", "un").Return(nuser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.FileName("a_file"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.FileName("a_file"))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
+	md5fake, _ := values.NewMD5("4d838d477ddf355Bc15df1db90bee0aa")
 	gfo := filestore.GetFileOutput{
 		ID: "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d",
 		Size: 9,
 		Format: "who cares",
 		Filename: "my_lovely_file",
-		MD5: "who cares",
+		MD5: *md5fake,
 		Stored: time.Now(),
 		Data: ioutil.NopCloser(strings.NewReader("012345678")),
 	}
@@ -549,17 +560,19 @@ func TestGetFileAsReader(t *testing.T) {
 	nsmock.On("GetUser", "reader").Return(ruser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme,
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme,
 		nodestore.Reader(*ouser), nodestore.Reader(*ruser), nodestore.FileName(""))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
+	md5fake, _ := values.NewMD5("3d838d477ddf955fc15df1db90bee0aa")
 	gfo := filestore.GetFileOutput{
 		ID: "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d",
 		Size: 9,
 		Format: "who cares",
 		Filename: "",
-		MD5: "who cares",
+		MD5: *md5fake,
 		Stored: time.Now(),
 		Data: ioutil.NopCloser(strings.NewReader("012345678")),
 	}
@@ -588,17 +601,19 @@ func TestGetFileAsAdmin(t *testing.T) {
 	nsmock.On("GetUser", "other").Return(ouser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ruser),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Reader(*ruser),
 		nodestore.FileName("bfile"))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
+	md5fake, _ := values.NewMD5("2d838d487ddf355fc15df1db90bee0aa")
 	gfo := filestore.GetFileOutput{
 		ID: "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d",
 		Size: 9,
 		Format: "who cares",
 		Filename: "afile",
-		MD5: "who cares",
+		MD5: *md5fake,
 		Stored: time.Now(),
 		Data: ioutil.NopCloser(strings.NewReader("012345678")),
 	}
@@ -629,17 +644,19 @@ func TestGetFilePublic(t *testing.T) {
 	nsmock.On("GetUser", "other").Return(ouser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ruser),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Reader(*ruser),
 		nodestore.FileName("bfile"), nodestore.Public(true))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
 
+	md5fake, _ := values.NewMD5("4d838d477ddf355fc15df1db90bee0aa")
 	gfo := filestore.GetFileOutput{
 		ID: "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d",
 		Size: 9,
 		Format: "who cares",
 		Filename: "afile",
-		MD5: "who cares",
+		MD5: *md5fake,
 		Stored: time.Now(),
 		Data: ioutil.NopCloser(strings.NewReader("012345678")),
 	}
@@ -674,7 +691,8 @@ func TestGetFileUnauthorized(t *testing.T) {
 	nsmock.On("GetUser", "other").Return(ouser, nil)
 
 	tme := time.Now()
-	node, _ := nodestore.NewNode(uid, *nuser, 12, "fakemd5", tme, nodestore.Reader(*ruser),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(uid, *nuser, 12, *md5, tme, nodestore.Reader(*ruser),
 		nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", uid).Return(node, nil)
@@ -706,7 +724,8 @@ func TestGetFileFailGetFromStorage(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -735,7 +754,8 @@ func TestSetNodePublicTrueAsOwner(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -746,7 +766,7 @@ func TestSetNodePublicTrueAsOwner(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -774,7 +794,8 @@ func TestSetNodePublicFalseAsAdmin(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -785,7 +806,7 @@ func TestSetNodePublicFalseAsAdmin(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -855,7 +876,8 @@ func TestSetNodePublicFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -885,7 +907,8 @@ func TestSetNodePublicFailSetPublic(t *testing.T) {
 		
 		nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 		tme := time.Now()
-		node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+		md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+		node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 		nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -909,7 +932,8 @@ func TestAddReaders(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -928,7 +952,7 @@ func TestAddReaders(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -964,7 +988,8 @@ func TestRemoveReaders(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"),
 		nodestore.Reader(*r1), nodestore.Reader(*r2))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
@@ -980,7 +1005,7 @@ func TestRemoveReaders(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -1016,7 +1041,8 @@ func TestRemoveReaderSelf(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"),
 		nodestore.Reader(*r1), nodestore.Reader(*r2))
 	
 	nsmock.On("GetUser", "r1").Return(r1, nil)
@@ -1030,7 +1056,7 @@ func TestRemoveReaderSelf(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -1108,7 +1134,8 @@ func TestAddAndRemoveReadersFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1147,7 +1174,8 @@ func TestAddReaderSelfFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1170,7 +1198,8 @@ func TestAddAndRemoveReadersFailGetReader(t *testing.T) {
 	o, _ := nodestore.NewUser(uuid.New(), "owner")
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1207,7 +1236,8 @@ func TestAddAndRemoveReadersFailAddRemoveReader(t *testing.T) {
 		
 		nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 		tme := time.Now()
-		node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+		md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+		node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 		nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1241,7 +1271,8 @@ func TestChangeOwner(t *testing.T) {
 
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"),
 		nodestore.Reader(*r1))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
@@ -1255,7 +1286,7 @@ func TestChangeOwner(t *testing.T) {
 	expected := &BlobNode {
 		ID: nid,
 		Size: 12,
-		MD5: "fakemd5",
+		MD5: *md5,
 		Stored: tme,
 		Filename: "foo",
 		Format: "",
@@ -1273,7 +1304,6 @@ func TestChangeOwner(t *testing.T) {
 	bnode, err = bs.ChangeOwner(*auser, nid, "new")
 	assert.Nil(t, err, "unexpected error")
 	assert.Equal(t, expected, bnode, "incorrect node")
-	
 }
 
 func TestChangeOwnerFailGetUser(t *testing.T) {
@@ -1335,7 +1365,8 @@ func TestChangeOwnerFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1344,7 +1375,6 @@ func TestChangeOwnerFailUnauthorized(t *testing.T) {
 	assert.Equal(t, expectederr, err, "incorrect error")
 	assert.Nil(t, bnode, "expected error")
 }
-
 
 func TestChangeOwnerFailGetNewOwner(t *testing.T) {
 	fsmock := new(fsmocks.FileStore)
@@ -1358,7 +1388,8 @@ func TestChangeOwnerFailGetNewOwner(t *testing.T) {
 	o, _ := nodestore.NewUser(uuid.New(), "owner")
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1391,7 +1422,8 @@ func TestChangeOwnerFailChangeOwner(t *testing.T) {
 		
 		nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 		tme := time.Now()
-		node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+		md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+		node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 		nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1417,7 +1449,8 @@ func TestDeleteNode(t *testing.T) {
 
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1493,7 +1526,8 @@ func TestDeleteNodeFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1521,7 +1555,8 @@ func TestDeleteNodeFailDeleteNode(t *testing.T) {
 		nsmock.On("GetUser", "un").Return(nuser, nil)
 		
 		tme := time.Now()
-		node, _ := nodestore.NewNode(nid, *nuser, 12, "fakemd5", tme, nodestore.FileName("foo"))
+		md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+		node, _ := nodestore.NewNode(nid, *nuser, 12, *md5, tme, nodestore.FileName("foo"))
 
 		nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1544,7 +1579,8 @@ func TestDeleteNodeFailDeleteFile(t *testing.T) {
 
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1579,10 +1615,11 @@ func testCopyNodeWithFnF(t *testing.T, filename string, format string) {
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	fid := "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d"
 	tme, _ := time.Parse("2000-01-01T01:01:01Z01:00", time.RFC3339)
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.Reader(*r1),
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.Reader(*r1),
 		nodestore.Reader(*r2), nodestore.FileName(filename), nodestore.Format(format))
 
-	pubnode, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme, nodestore.Public(true),
+	pubnode, _ := nodestore.NewNode(nid, *o, 12, *md5, tme, nodestore.Public(true),
 		nodestore.FileName(filename), nodestore.Format(format))
 
 
@@ -1612,14 +1649,16 @@ func testCopyNodeWithFnF(t *testing.T, filename string, format string) {
 		nsmock.On("GetUser", tc.user.GetUserName()).Return(&tc.nuser, nil)
 		nsmock.On("GetNode", nid).Return(tc.node, nil)
 		uuidmock.On("GetUUID").Return(newnid)
+		md5fake, _ := values.NewMD5("4d838d477ddf355fc15df1db90bee0aa")
 		fsmock.On("CopyFile", fid, newfid).Return(
 			&filestore.FileInfo{
-				ID: newfid, Size: 120, Format: "ignored", Filename: "ignored", MD5: "ignored",
+				ID: newfid, Size: 120, Format: "ignored", Filename: "ignored", MD5: *md5fake,
 				Stored: newtme},
 			nil,
 		)
 
-		newnode, _ := nodestore.NewNode(newnid, tc.nuser, 12, "fakemd5", newtme,
+		md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+		newnode, _ := nodestore.NewNode(newnid, tc.nuser, 12, *md5, newtme,
 			nodestore.FileName(filename), nodestore.Format(format))
 		nsmock.On("StoreNode", newnode).Return(nil)
 
@@ -1628,7 +1667,7 @@ func testCopyNodeWithFnF(t *testing.T, filename string, format string) {
 		expected := &BlobNode {
 			ID: newnid,
 			Size: 12,
-			MD5: "fakemd5",
+			MD5: *md5,
 			Stored: newtme,
 			Filename: filename,
 			Format: format,
@@ -1699,7 +1738,8 @@ func TestCopyNodeFailUnauthorized(t *testing.T) {
 	
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	tme := time.Now()
-	node, _ := nodestore.NewNode(nid, *nowner, 12, "fakemd5", tme, nodestore.FileName("foo"))
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *nowner, 12, *md5, tme, nodestore.FileName("foo"))
 
 	nsmock.On("GetNode", nid).Return(node, nil)
 
@@ -1716,7 +1756,8 @@ func TestCopyNodeFailCopyFile(t *testing.T) {
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	fid := "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d"
 	tme, _ := time.Parse("2000-01-01T01:01:01Z01:00", time.RFC3339)
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme)
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme)
 
 	newnid, _ := uuid.Parse("b6f2d8b7-429e-4639-b2d9-c619e4e9f4e1")
 	newfid := "b6/f2/d8/b6f2d8b7-429e-4639-b2d9-c619e4e9f4e1"
@@ -1744,7 +1785,8 @@ func TestCopyNodeFailStoreNode(t *testing.T) {
 	nid, _ := uuid.Parse("f6029a11-0914-42b3-beea-fed420f75d7d")
 	fid := "f6/02/9a/f6029a11-0914-42b3-beea-fed420f75d7d"
 	tme, _ := time.Parse("2000-01-01T01:01:01Z01:00", time.RFC3339)
-	node, _ := nodestore.NewNode(nid, *o, 12, "fakemd5", tme)
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
+	node, _ := nodestore.NewNode(nid, *o, 12, *md5, tme)
 
 	newnid, _ := uuid.Parse("b6f2d8b7-429e-4639-b2d9-c619e4e9f4e1")
 	newfid := "b6/f2/d8/b6f2d8b7-429e-4639-b2d9-c619e4e9f4e1"
@@ -1758,14 +1800,15 @@ func TestCopyNodeFailStoreNode(t *testing.T) {
 	nsmock.On("GetUser", "owner").Return(o, nil)
 	nsmock.On("GetNode", nid).Return(node, nil)
 	uuidmock.On("GetUUID").Return(newnid)
+	md5fake, _ := values.NewMD5("4d838d477ddf355fc15df1db90bee0aa")
 	fsmock.On("CopyFile", fid, newfid).Return(
 		&filestore.FileInfo{
-			ID: newfid, Size: 120, Format: "ignored", Filename: "ignored", MD5: "ignored",
+			ID: newfid, Size: 120, Format: "ignored", Filename: "ignored", MD5: *md5fake,
 			Stored: storedtime},
 		nil,
 	)
 
-	newnode, _ := nodestore.NewNode(newnid, *o, 12, "fakemd5", storedtime)
+	newnode, _ := nodestore.NewNode(newnid, *o, 12, *md5, storedtime)
 	nsmock.On("StoreNode", newnode).Return(errors.New("some error here"))
 
 	bnode, err := bs.CopyNode(*owner, nid)

--- a/core/values/values.go
+++ b/core/values/values.go
@@ -1,0 +1,27 @@
+// Package values contains simple wrapper classes for value types, such as MD5 strings.
+package values
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var md5regex = regexp.MustCompile("^[a-fA-F0-9]{32}$")
+
+// MD5 contains a valid MD5 string.
+type MD5 struct {
+	md5 string
+}
+
+// NewMD5 creates a new MD5.
+func NewMD5(md5 string) (*MD5, error) {
+	if !md5regex.MatchString(md5) {
+		return nil, fmt.Errorf("%v is not an MD5 string", md5)
+	}
+	return &MD5{md5}, nil
+}
+
+// GetMD5 returns the MD5 string.
+func (md5 *MD5) GetMD5() string {
+	return md5.md5
+}

--- a/core/values/values_test.go
+++ b/core/values/values_test.go
@@ -1,0 +1,37 @@
+package values
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewMD5(t *testing.T) {
+	for _, m := range []string{
+		"5d838d477ddf355fc15df1db90bee0aa",
+		"1B9554867D35F0D59E4705F6B2712CD1",
+		"0123456789abcdefABCDEF0123456789",
+	} {
+		md5, err := NewMD5(m)
+		assert.Nil(t, err, "unexpected error")
+		assert.Equal(t, m, md5.GetMD5(), "incorrect md5")
+	}
+}
+
+func TestNewMD5Fail(t *testing.T) {
+	for _, m := range []string{
+		"a",
+		"1b9554867d35f0d59e4705f6b2712cd",
+		"1b9554867d35f0d59e4705f6b2712cd1c",
+		"1b9554867d35X0d59e4705f6b2712cd1",
+		"1b9554867d35x0d59e4705f6b2712cd1",
+		"1b9554867d35f0d%9e4705f6b2712cd1",
+		"1b9554867d35f0d-9e4705f6b2712cd1",
+		"1b9554867d35f0d_9e4705f6b2712cd1",
+	} {
+		md5, err := NewMD5(m)
+		assert.Nil(t, md5, "expected error")
+		assert.Equal(t, errors.New(m + " is not an MD5 string"), err, "incorrect error")
+	}
+
+}

--- a/filestore/interface.go
+++ b/filestore/interface.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"github.com/kbase/blobstore/core/values"
 )
 
 // TODO INPUT may need limits for strings.
@@ -79,7 +81,7 @@ type FileInfo struct {
 	// The filename.
 	Filename string
 	// The MD5 of the file.
-	MD5 string
+	MD5 values.MD5
 	// The time the file was stored.
 	Stored time.Time
 }
@@ -95,7 +97,7 @@ type GetFileOutput struct {
 	// The filename.
 	Filename string
 	// The MD5 of the file.
-	MD5 string
+	MD5 values.MD5
 	// The time the file was stored.
 	Stored time.Time
 	// The file's contents.

--- a/filestore/s3_test.go
+++ b/filestore/s3_test.go
@@ -1,6 +1,7 @@
 package filestore
 
 import (
+	"github.com/kbase/blobstore/core/values"
 	"fmt"
 	"os"
 	"bytes"
@@ -128,13 +129,14 @@ func (t *TestSuite) storeAndGet(filename string, format string) {
 	// down, and so if the time is very close to the next second, at the time the test occurs
 	// it's flipped over to the next second and the test fails.
 	testhelpers.AssertCloseToNow(t.T(), stored, 2 * time.Second)
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	expected := &FileInfo{
 		ID:       "myid",
 		Size:     12,
 		Stored:   stored, // fake
 		Filename: filename,
 		Format:   format,
-		MD5:      "5d838d477ddf355fc15df1db90bee0aa",
+		MD5:      *md5,
 	}
 
 	t.Equal(expected, res, "unexpected output")
@@ -150,7 +152,7 @@ func (t *TestSuite) storeAndGet(filename string, format string) {
 		Size:     12,
 		Filename: filename,
 		Format:   format,
-		MD5:      "5d838d477ddf355fc15df1db90bee0aa",
+		MD5:      *md5,
 		Data:     ioutil.NopCloser(strings.NewReader("")), // fake
 		Stored:   stored,
 	}
@@ -276,12 +278,13 @@ func (t *TestSuite) TestGetWithoutMetaData() {
 	t.Equal("012345678910", string(b), "incorrect object contents")
 	obj.Data = ioutil.NopCloser(strings.NewReader("")) // fake
 
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	expected := &GetFileOutput{
 		ID:       id,
 		Size:     12,
 		Filename: "",
 		Format:   "",
-		MD5:      "5d838d477ddf355fc15df1db90bee0aa",
+		MD5:      *md5,
 		Data:     ioutil.NopCloser(strings.NewReader("")), // fake
 		Stored:   obj.Stored, //fake
 	}
@@ -391,12 +394,13 @@ func (t *TestSuite) copy(
 	// it's flipped over to the next second and the test fails.
 	testhelpers.AssertCloseToNow(t.T(), fi.Stored, 2 * time.Second)
 	t.True(fi.Stored.After(res.Stored), "expected copy time later than source time")
+	md5, _ := values.NewMD5("5d838d477ddf355fc15df1db90bee0aa")
 	fiexpected := FileInfo{
 		ID: strings.TrimSpace(dstobj),
 		Size: 12,
 		Format: format,
 		Filename: filename,
-		MD5: "5d838d477ddf355fc15df1db90bee0aa",
+		MD5: *md5,
 		Stored: fi.Stored, // fake
 	}
 	t.Equal(&fiexpected, fi, "incorrect copy result")
@@ -412,7 +416,7 @@ func (t *TestSuite) copy(
 		Size:     12,
 		Filename: filename,
 		Format:   format,
-		MD5:      "5d838d477ddf355fc15df1db90bee0aa",
+		MD5:      *md5,
 		Data:     ioutil.NopCloser(strings.NewReader("")), // fake
 		Stored:   fi.Stored, // fake
 	}

--- a/nodestore/interface.go
+++ b/nodestore/interface.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kbase/blobstore/core/values"
+
 	"github.com/google/uuid"
 )
 
@@ -44,7 +46,7 @@ type Node struct {
 	filename string
 	format   string
 	size     int64
-	md5      string
+	md5      values.MD5
 	stored   time.Time
 	public   bool
 }
@@ -87,7 +89,7 @@ func NewNode(
 	id uuid.UUID,
 	owner User,
 	size int64,
-	md5 string,
+	md5 values.MD5,
 	stored time.Time,
 	options ...func(*Node) error) (*Node, error) {
 
@@ -147,7 +149,7 @@ func (n *Node) GetSize() int64 {
 }
 
 // GetMD5 returns the MD5 of the file associated with the node.
-func (n *Node) GetMD5() string {
+func (n *Node) GetMD5() values.MD5 {
 	return n.md5
 }
 

--- a/nodestore/interface_test.go
+++ b/nodestore/interface_test.go
@@ -1,6 +1,7 @@
 package nodestore
 
 import (
+	"github.com/kbase/blobstore/core/values"
 	"time"
 	"errors"
 	"github.com/stretchr/testify/assert"
@@ -27,11 +28,12 @@ func TestNewNodeMin(t *testing.T) {
 	id := uuid.New()
 	owner, _ := NewUser(uuid.New(), " owner ")
 	tm := time.Now()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, err := NewNode(
 		id,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tm,
 		)
 	assert.Nil(t, err, "unexpected error")
@@ -40,7 +42,7 @@ func TestNewNodeMin(t *testing.T) {
 	assert.Equal(t, id, n.GetID(), "incorrect ID")
 	assert.Equal(t, *owner, n.GetOwner(), "incorrect owner")
 	assert.Equal(t, int64(67), n.GetSize(), "incorrect size")
-	assert.Equal(t, "1b9554867d35f0d59e4705f6b2712cd1", n.GetMD5(), "incorrect MD5")
+	assert.Equal(t, *md5, n.GetMD5(), "incorrect MD5")
 	assert.Equal(t, tm, n.GetStoredTime(), "incorrect store time")
 	assert.Equal(t, "", n.GetFormat(), "incorrect format")
 	assert.Equal(t, "", n.GetFileName(), "incorrect filename")
@@ -54,11 +56,12 @@ func TestNewNodeFull(t *testing.T) {
 	r1, _ := NewUser(uuid.New(), " r1 ")
 	r2, _ := NewUser(uuid.New(), " r2")
 	tm := time.Now()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, err := NewNode(
 		id,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tm,
 		Format("    txt   "),
 		FileName("   file.txt   "),
@@ -71,7 +74,7 @@ func TestNewNodeFull(t *testing.T) {
 	assert.Equal(t, id, n.GetID(), "incorrect ID")
 	assert.Equal(t, *owner, n.GetOwner(), "incorrect owner")
 	assert.Equal(t, int64(67), n.GetSize(), "incorrect size")
-	assert.Equal(t, "1b9554867d35f0d59e4705f6b2712cd1", n.GetMD5(), "incorrect MD5")
+	assert.Equal(t, *md5, n.GetMD5(), "incorrect MD5")
 	assert.Equal(t, tm, n.GetStoredTime(), "incorrect store time")
 	assert.Equal(t, "txt", n.GetFormat(), "incorrect format")
 	assert.Equal(t, "file.txt", n.GetFileName(), "incorrect filename")
@@ -83,11 +86,12 @@ func TestNodeImmutable(t *testing.T) {
 	owner, _ := NewUser(uuid.New(), " owner ")
 	r1, _ := NewUser(uuid.New(), " r1 ")
 	r2, _ := NewUser(uuid.New(), " r2")
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		uuid.New(),
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		time.Now(),
 		Reader(*r1),
 		)
@@ -100,11 +104,12 @@ func TestNodeImmutable(t *testing.T) {
 
 func TestNodeBadInput(t *testing.T) {
 	owner, _ := NewUser(uuid.New(), " owner ")
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, err := NewNode(
 		uuid.New(),
 		*owner,
 		0,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		time.Now(),
 		)
 	assert.Nil(t, n, "expected nil object")
@@ -116,11 +121,12 @@ func TestNodeWithPublic(t *testing.T) {
 	r1, _ := NewUser(uuid.New(), " r1 ")
 	tme := time.Now()
 	nid := uuid.New()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1),
 		)
@@ -129,7 +135,7 @@ func TestNodeWithPublic(t *testing.T) {
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1),
 		Public(true),
@@ -148,11 +154,12 @@ func TestNodeWithOwner(t *testing.T) {
 	r1, _ := NewUser(uuid.New(), " r1 ")
 	tme := time.Now()
 	nid := uuid.New()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1),
 		)
@@ -161,7 +168,7 @@ func TestNodeWithOwner(t *testing.T) {
 		nid,
 		*newowner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*owner),
 		Reader(*r1),
@@ -182,7 +189,7 @@ func TestNodeWithOwner(t *testing.T) {
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1),
 		Reader(*newowner),
@@ -199,11 +206,12 @@ func TestNodeWithReaders(t *testing.T) {
 	r1, _ := NewUser(uuid.New(), " r1 ")
 	tme := time.Now()
 	nid := uuid.New()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1),
 		)
@@ -215,7 +223,7 @@ func TestNodeWithReaders(t *testing.T) {
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1), Reader(*r2), Reader(*r3),
 		)
@@ -234,11 +242,12 @@ func TestNodeWithoutReaders(t *testing.T) {
 	r3, _ := NewUser(uuid.New(), " r3 ")
 	tme := time.Now()
 	nid := uuid.New()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1), Reader(*r2), Reader(*r3),
 		)
@@ -248,7 +257,7 @@ func TestNodeWithoutReaders(t *testing.T) {
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1), Reader(*r3),
 		)
@@ -267,11 +276,12 @@ func TestNodeHasReader(t *testing.T) {
 	r3, _ := NewUser(uuid.New(), " r3 ")
 	tme := time.Now()
 	nid := uuid.New()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*owner,
 		67,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Reader(*r1), Reader(*r3),
 		)

--- a/nodestore/mongostore_test.go
+++ b/nodestore/mongostore_test.go
@@ -1,6 +1,7 @@
 package nodestore
 
 import (
+	"github.com/kbase/blobstore/core/values"
 	"fmt"
 	"time"
 	"github.com/google/uuid"
@@ -271,7 +272,8 @@ func (t *TestSuite) TestStoreAndGetNodeMinimal() {
 	oid := uuid.New()
 	own, _ := NewUser(oid, "owner")
 	tme := time.Now()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, tme)
 	err = mns.StoreNode(n)
 	if err != nil {
 		t.Fail(err.Error())
@@ -282,7 +284,7 @@ func (t *TestSuite) TestStoreAndGetNodeMinimal() {
 	}
 	// time loses precision when stored in mongo
 	testhelpers.AssertWithin1MS(t.T(), tme, ngot.GetStoredTime())
-	nexpected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", ngot.GetStoredTime())
+	nexpected, _ := NewNode(nid, *own, 78, *md5, ngot.GetStoredTime())
 	t.Equal(nexpected, ngot, "incorrect node")
 }
 
@@ -300,11 +302,12 @@ func (t *TestSuite) TestStoreAndGetNodeMaximal() {
 	r1, _ := NewUser(rid1, "reader1")
 	r2, _ := NewUser(rid2, "reader2")
 	tme := time.Now()
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
 	n, _ := NewNode(
 		nid,
 		*own,
 		78,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		tme,
 		Format("json"),
 		FileName("fn.txt"),
@@ -326,7 +329,7 @@ func (t *TestSuite) TestStoreAndGetNodeMaximal() {
 		nid,
 		*own,
 		78,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		ngot.GetStoredTime(),
 		Format("json"),
 		FileName("fn.txt"),
@@ -355,12 +358,13 @@ func (t *TestSuite) TestStoreNodeFailWithSameID() {
 	oid := uuid.New()
 	own, _ := NewUser(oid, "owner")
 	tme := time.Now()
-	n1, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n1, _ := NewNode(nid, *own, 78, *md5, tme)
 	err = mns.StoreNode(n1)
 	if err != nil {
 		t.Fail(err.Error())
 	}
-	n2, _ := NewNode(nid, *own, 82, "189e725f4587b679740f0f7783745056", time.Now())
+	n2, _ := NewNode(nid, *own, 82, *md5, time.Now())
 	err = mns.StoreNode(n2)
 	t.Equal(fmt.Errorf("Node %v already exists", nid.String()), err, "incorrect error")
 }
@@ -372,7 +376,8 @@ func (t *TestSuite) TestGetNodeFailNoNode() {
 	oid := uuid.New()
 	own, _ := NewUser(oid, "owner")
 	tme := time.Now()
-	n1, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n1, _ := NewNode(nid, *own, 78, *md5, tme)
 	err = mns.StoreNode(n1)
 	t.Nil(err, "expected no error")
 
@@ -387,7 +392,8 @@ func (t *TestSuite) TestDeleteNode() {
 	t.Nil(err, "expected no error")
 	nid := uuid.New()
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
 
@@ -403,7 +409,8 @@ func (t *TestSuite) TestDeleteNodeFailNoNode() {
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(uuid.New(), *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(uuid.New(), *own, 78, *md5, time.Now())
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
 
@@ -417,7 +424,8 @@ func (t *TestSuite) TestSetNodePublic() {
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
 
@@ -431,7 +439,7 @@ func (t *TestSuite) TestSetNodePublic() {
 		nid,
 		*own,
 		78,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		ngot.GetStoredTime(),
 		Public(true),
 		)
@@ -447,7 +455,7 @@ func (t *TestSuite) TestSetNodePublic() {
 		nid,
 		*own,
 		78,
-		"1b9554867d35f0d59e4705f6b2712cd1",
+		*md5,
 		ngot.GetStoredTime(),
 		Public(false),
 		)
@@ -458,7 +466,8 @@ func (t *TestSuite) TestSetNodePublicFailNoNode() {
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(uuid.New(), *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(uuid.New(), *own, 78, *md5, time.Now())
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
 
@@ -472,7 +481,8 @@ func (t *TestSuite) TestAddAndRemoveReader() {
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -487,7 +497,7 @@ func (t *TestSuite) TestAddAndRemoveReader() {
 
 	tme := node.GetStoredTime()
 	
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme, Reader(*r1))
+	expected, _ := NewNode(nid, *own, 78, *md5, tme, Reader(*r1))
 	t.Equal(expected, node, "incorrect node")
 	
 	err = mns.AddReader(nid, *r2)
@@ -495,7 +505,7 @@ func (t *TestSuite) TestAddAndRemoveReader() {
 	node, err = mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 	
-	expected, _= NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme,
+	expected, _= NewNode(nid, *own, 78, *md5, tme,
 		Reader(*r1), Reader(*r2))
 	t.Equal(expected, node, "incorrect node")
 	
@@ -504,7 +514,7 @@ func (t *TestSuite) TestAddAndRemoveReader() {
 	node, err = mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 	
-	expected, _ = NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme, Reader(*r2))
+	expected, _ = NewNode(nid, *own, 78, *md5, tme, Reader(*r2))
 	t.Equal(expected, node, "incorrect node")
 
 	err = mns.RemoveReader(nid, *r2)
@@ -512,7 +522,7 @@ func (t *TestSuite) TestAddAndRemoveReader() {
 	node, err = mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 	
-	expected, _ = NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	expected, _ = NewNode(nid, *own, 78, *md5, tme)
 	t.Equal(expected, node, "incorrect node")
 }
 
@@ -522,7 +532,8 @@ func (t *TestSuite) TestAddOwnerAsReader() {
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -533,7 +544,7 @@ func (t *TestSuite) TestAddOwnerAsReader() {
 	node, err := mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", node.GetStoredTime())
+	expected, _ := NewNode(nid, *own, 78, *md5, node.GetStoredTime())
 	t.Equal(expected, node, "incorrect node")
 }
 
@@ -543,7 +554,8 @@ func (t *TestSuite) TestRemoveOwnerAsReader() {
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -554,7 +566,7 @@ func (t *TestSuite) TestRemoveOwnerAsReader() {
 	node, err := mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", node.GetStoredTime())
+	expected, _ := NewNode(nid, *own, 78, *md5, node.GetStoredTime())
 	t.Equal(expected, node, "incorrect node")
 }
 
@@ -564,7 +576,8 @@ func (t *TestSuite) TestAddReaderTwice() {
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -575,7 +588,7 @@ func (t *TestSuite) TestAddReaderTwice() {
 	t.Nil(err, "expected no error")
 	
 	node, err := mns.GetNode(nid)
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", node.GetStoredTime(),
+	expected, _ := NewNode(nid, *own, 78, *md5, node.GetStoredTime(),
 		Reader(*r))
 	t.Nil(err, "expected no error")
 	t.Equal(expected, node, "incorrect node")
@@ -595,7 +608,8 @@ func (t *TestSuite) TestRemoveNonReader() {
 	own, _ := NewUser(uuid.New(), "owner")
 	r1, _ := NewUser(uuid.New(), "r1")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now(), Reader(*r1))
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now(), Reader(*r1))
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -606,7 +620,7 @@ func (t *TestSuite) TestRemoveNonReader() {
 
 	node, err := mns.GetNode(nid)
 	t.Nil(err, "expected no error")
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", node.GetStoredTime(),
+	expected, _ := NewNode(nid, *own, 78, *md5, node.GetStoredTime(),
 		Reader(*r1))
 	t.Equal(expected, node, "incorrect node")
 
@@ -623,7 +637,8 @@ func (t *TestSuite) TestAddReaderFailNoNode() {
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(uuid.New(), *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(uuid.New(), *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -637,7 +652,8 @@ func (t *TestSuite) TestRemoveReaderFailNoNode() {
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(uuid.New(), *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(uuid.New(), *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -654,7 +670,8 @@ func (t *TestSuite) TestChangeOwner() {
 	own, _ := NewUser(uuid.New(), "owner")
 	newown, _ := NewUser(uuid.New(), "newowner")
 	nid := uuid.New()
-	n, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(nid, *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")
@@ -664,7 +681,7 @@ func (t *TestSuite) TestChangeOwner() {
 
 	tme := node.GetStoredTime()
 	
-	expected, _ := NewNode(nid, *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme)
+	expected, _ := NewNode(nid, *own, 78, *md5, tme)
 	t.Equal(expected, node, "incorrect node")
 
 	// test that changing to the current owner has no effect
@@ -679,7 +696,7 @@ func (t *TestSuite) TestChangeOwner() {
 	node, err = mns.GetNode(nid)
 	t.Nil(err, "expected no error")
 	
-	expected, _= NewNode(nid, *newown, 78, "1b9554867d35f0d59e4705f6b2712cd1", tme, Reader(*own))
+	expected, _= NewNode(nid, *newown, 78, *md5, tme, Reader(*own))
 	t.Equal(expected, node, "incorrect node")
 }
 
@@ -687,7 +704,8 @@ func (t *TestSuite) TestChangeOwnerFailNoNode() {
 	mns, err := NewMongoNodeStore(t.client.Database(testDB))
 	t.Nil(err, "expected no error")
 	own, _ := NewUser(uuid.New(), "owner")
-	n, _ := NewNode(uuid.New(), *own, 78, "1b9554867d35f0d59e4705f6b2712cd1", time.Now())
+	md5, _ := values.NewMD5("1b9554867d35f0d59e4705f6b2712cd1")
+	n, _ := NewNode(uuid.New(), *own, 78, *md5, time.Now())
 
 	err = mns.StoreNode(n)
 	t.Nil(err, "expected no error")

--- a/service/server.go
+++ b/service/server.go
@@ -412,7 +412,7 @@ func fromNodeToNode(node *core.BlobNode) map[string]interface{} {
 		"file": map[string]interface{}{
 			"name":     node.Filename,
 			"size":     node.Size,
-			"checksum": map[string]string{"md5": node.MD5},
+			"checksum": map[string]string{"md5": node.MD5.GetMD5()},
 		},
 	}
 }


### PR DESCRIPTION
Just use a wrapper struct for MD5 strings. That checks them at the source
and ensures they're ok everywhere else.

This check is important to ensure Minio isn't running in S3 incompatibility
mode.