### PR TITLE
 Support format in multipart 

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,21 +234,23 @@ method is used rather than this one.
 
 ```
 AUTHORIZATION REQUIRED
-POST /node[?filename=<filename>&format=<file format>]
+POST /node
 <multipart form>
 
 RETURNS: a Node.
 ```
 
-The form must contain a single part called `upload` where the part contents are the file to be
+The form **MUST** contain a part called `upload` where the part contents are the file to be
 uploaded.
 The part must have an accurate `Content-Length` header specifing the size of the file, **not**
 the entire multipart form.
 
-`filename` can be at most 256 characters with no control characters. `filename` takes precedence
-over any filename provided in the part's `Content-Disposition` header. Any filename provided in
-that header must meet the same requirements as `filename` provided in the query.  
-`format` can be at most 100 characters with no control characters.
+The form **may** contain a part called `format` where the part contents are the format of the
+file, equivalent to the `format` query paramter for the standard upload method and with the same
+restrictions.
+
+Any file name provided in the `Content-Disposition` header can be at most 256 characters with no
+control characters.
 
 ### Curl example
 

--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ The part must have an accurate `Content-Length` header specifing the size of the
 the entire multipart form.
 
 The form **may** contain a part called `format` where the part contents are the format of the
-file, equivalent to the `format` query paramter for the standard upload method and with the same
-restrictions.
+file, equivalent to the `format` query parameter for the standard upload method and with the same
+restrictions. The `format` part **MUST** come before the `upload` part.
 
 Any file name provided in the `Content-Disposition` header can be at most 256 characters with no
 control characters.

--- a/service/server.go
+++ b/service/server.go
@@ -31,6 +31,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// TODO FORMAT - for MIME upload, support format part (1st) and don't support query params
+// TODO TIMEOUT on headers - check timeout article for others
+// TODO MAXLEN on headers
+// TODO JAVA test MIME upload w/ content length
+
 const (
 	service      = "BlobStore"
 	formCopyData = "copy_data"


### PR DESCRIPTION
Might as well support format as well since the Java client supports it.
Remove the now redundant query parameters.