### PR TITLE
 Clean up python MIME upload example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,18 @@ curl -H "Authorization: OAuth $KBASE_TOKEN" \
 ### Python example
 
 ```python
+import os
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
-df = open('mydata.fasta', 'rb')
-files = {'upload': ('mydata.fasta', df, None, {'content-length': 67452})}
-
+df = open(filename, 'rb')
+files = {'upload': (filename, df, None, {'Content-Length': os.path.getsize(filename)})}
 mpe = MultipartEncoder(fields=files)
-headers = {'content-type': mpe.content_type,
-           'authorization': 'OAuth $KBASE_TOKEN'}
-res = requests.post('http://<host>/node', headers=headers, data=mpe, stream=True) 
+headers = {'Content-Type': mpe.content_type,
+           'authorization': 'OAuth ' + token}
+
+res = requests.post('http://<host>/node', headers=headers, data=mpe, stream=True)
+res.json()
 ```
 
 ### Java example

--- a/service/server.go
+++ b/service/server.go
@@ -31,9 +31,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// TODO TIMEOUT on headers - check timeout article for others
-// TODO MAXLEN on headers
-
 const (
 	service      = "BlobStore"
 	formCopyData = "copy_data"


### PR DESCRIPTION
Also remove some TODOs:

Default max header len is 1MB, so adding a timeout as well doesn't
really seem necessary.

For details:
https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/