### PR TITLE
Add range header to s3.go

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -243,17 +243,17 @@ func authok(user *auth.User, nodeuser *nodestore.User, node *nodestore.Node) boo
 
 // GetFile gets the file from a node. Returns NoBlobError and UnauthorizedError.
 func (bs *BlobStore) GetFile(user *auth.User, id uuid.UUID,
-) (data io.ReadCloser, size int64, filename string, err error) {
+) (data io.ReadCloser, size int64, filename string, position int, offset int, err error) {
 	node, err := bs.Get(user, id) // checks auth
 	if err != nil {
 		return nil, 0, "", err
 	}
-	f, err := bs.fileStore.GetFile(uuidToFilePath(id))
+	f, err := bs.fileStore.GetFile(uuidToFilePath(id),position,offset)
 	if err != nil {
 		// errors should only occur for unusual situations here since we got the node
 		return nil, 0, "", err
 	}
-	return f.Data, f.Size, node.Filename, nil
+	return f.Data, f.Size, f.Position, f.Offset, node.Filename, nil
 }
 
 // SetNodePublic sets whether a node can be read by anyone, including anonymous users.

--- a/filestore/interface.go
+++ b/filestore/interface.go
@@ -104,6 +104,8 @@ type GetFileOutput struct {
 	// The MD5 of the file. May be nil if the backend service does not provide an MD5 - for
 	// example many S3 upload methods.
 	MD5 *values.MD5
+	// The range of bits to acquire
+	Range *string
 	// The time the file was stored.
 	Stored time.Time
 	// The file's contents.
@@ -130,7 +132,7 @@ type FileStore interface {
 	StoreFile(le *logrus.Entry, p *StoreFileParams) (*FileInfo, error)
 	// Get a file by the ID of the file.
 	// Returns NoFileError if there is no file by the given ID.
-	GetFile(id string) (*GetFileOutput, error)
+	GetFile(id string, position int, offset int) (*GetFileOutput, error)
 	// DeleteFile deletes a file. Deleting a file that does not exist is not an error.
 	DeleteFile(id string) error
 	// CopyFile copies a file from one ID to another.

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -188,15 +188,15 @@ func (fs *S3FileStore) getFileInfo(id string, strictMD5 bool) (*FileInfo, error)
 // GetFile Get a file by the ID of the file.
 // The user is responsible for closing the reader.
 
-func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
+func (fs *S3FileStore) GetFile(id string, position int, offset int) (out *GetFileOutput, err error) {
 	id = strings.TrimSpace(id)
 
 // ** Add S3 Range Header **
 // calculate position
-// input.Range = aws.String(fmt.Sprintf("bytes=%d-%d", Position, Offset))
-
+    blobrange := aws.String(fmt.Sprintf("bytes=%d-%d", position, offset))
+// Looks like we need to add `Position, Offset` to the S3FileStore struct?
 // Get particular chunk of object
-//result, err := o.Service().GetObject(input)	
+//  result, err := o.Service().GetObject(input)	
 
 // Alternate Range
 //	Range:  aws.String("bytes=" + strconv.FormatInt(*obj.ContentLength, 10) + "-"),
@@ -225,6 +225,7 @@ func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
 			Size:     *res.ContentLength,
 			Filename: getMeta(res.Metadata, "Filename"),
 			Format:   getMeta(res.Metadata, "Format"),
+			Range:    blobrange,
 			MD5:      md5,
 			Data:     res.Body,
 			Stored:   res.LastModified.UTC(),

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -187,11 +187,21 @@ func (fs *S3FileStore) getFileInfo(id string, strictMD5 bool) (*FileInfo, error)
 
 // GetFile Get a file by the ID of the file.
 // The user is responsible for closing the reader.
-// ** Add S3 Range Header **
+
 func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
 	id = strings.TrimSpace(id)
+
+// ** Add S3 Range Header **
+// calculate position
+// input.Range = aws.String(fmt.Sprintf("bytes=%d-%d", Position, Offset))
+
+// Get particular chunk of object
+//result, err := o.Service().GetObject(input)	
+
+// Alternate Range
 //	Range:  aws.String("bytes=" + strconv.FormatInt(*obj.ContentLength, 10) + "-"),
-//  Also see https://github.com/minio/minio/blob/master/cmd/httprange.go
+
+
 	if id == "" {
 		return nil, errors.New("id cannot be empty or whitespace only")
 	}

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -205,7 +205,8 @@ func (fs *S3FileStore) GetFile(id string, position int, offset int) (out *GetFil
 	if id == "" {
 		return nil, errors.New("id cannot be empty or whitespace only")
 	}
-	res, err := fs.s3client.GetObject(&s3.GetObjectInput{Bucket: &fs.bucket, Key: &id})
+	// This is where the magic happens
+	res, err := fs.s3client.GetObject(&s3.GetObjectInput{Bucket: &fs.bucket, Key: &id, Range: blobrange})
 	if err != nil {
 		switch err.(awserr.Error).Code() {
 		case s3.ErrCodeNoSuchKey:

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -187,15 +187,13 @@ func (fs *S3FileStore) getFileInfo(id string, strictMD5 bool) (*FileInfo, error)
 
 // GetFile Get a file by the ID of the file.
 // The user is responsible for closing the reader.
-
-// Add 2 headers to the request for offset and # of bytes 
-
-func (fs *S3FileStore) GetFile(id string, offset int, bytes int) (out *GetFileOutput, err error) {
+// ** Add S3 Range Header **
+func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return nil, errors.New("id cannot be empty or whitespace only")
 	}
-	res, err := fs.s3client.GetObject(&s3.GetObjectInput{Bucket: &fs.bucket, Key: &id, Offset: &offset, Bytes: &bytes})
+	res, err := fs.s3client.GetObject(&s3.GetObjectInput{Bucket: &fs.bucket, Key: &id})
 	if err != nil {
 		switch err.(awserr.Error).Code() {
 		case s3.ErrCodeNoSuchKey:
@@ -212,8 +210,6 @@ func (fs *S3FileStore) GetFile(id string, offset int, bytes int) (out *GetFileOu
 	md5, _ := values.NewMD5(md5str)
 	return &GetFileOutput{
 			ID:       id,
-			Offset:	  offset,
-			Bytes:    bytes,
 			Size:     *res.ContentLength,
 			Filename: getMeta(res.Metadata, "Filename"),
 			Format:   getMeta(res.Metadata, "Format"),

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -191,6 +191,7 @@ func (fs *S3FileStore) getFileInfo(id string, strictMD5 bool) (*FileInfo, error)
 func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
 	id = strings.TrimSpace(id)
 //	Range:  aws.String("bytes=" + strconv.FormatInt(*obj.ContentLength, 10) + "-"),
+//  Also see https://github.com/minio/minio/blob/master/cmd/httprange.go
 	if id == "" {
 		return nil, errors.New("id cannot be empty or whitespace only")
 	}

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -190,6 +190,7 @@ func (fs *S3FileStore) getFileInfo(id string, strictMD5 bool) (*FileInfo, error)
 // ** Add S3 Range Header **
 func (fs *S3FileStore) GetFile(id string) (out *GetFileOutput, err error) {
 	id = strings.TrimSpace(id)
+//	Range:  aws.String("bytes=" + strconv.FormatInt(*obj.ContentLength, 10) + "-"),
 	if id == "" {
 		return nil, errors.New("id cannot be empty or whitespace only")
 	}


### PR DESCRIPTION
Create initial range header at db layer in s3.go first, before moving on to core.go & server.go.