### PR TITLE
S3 disable ssl verify

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,10 @@ const (
 	// KeyS3DisableSSL is the configuration key that determines whether SSL is to be used.
 	// any value other than 'true' is treated as false.
 	KeyS3DisableSSL = "s3-disable-ssl"
+	// KeyS3DisableSSLVerify is the configuration key that determines whether to verify the
+	// SSL certificate of the remote servers (in case a self-signed cert is used).
+	// any value other than 'true' is treated as false.
+	KeyS3DisableSSLVerify = "s3-disable-ssl-verify"
 	// KeyS3Region is the configuration key where the value is the S3 region
 	KeyS3Region = "s3-region"
 	// KeyAuthURL is the configuration key where the value is the KBase auth server URL
@@ -69,6 +73,8 @@ type Config struct {
 	S3AccessSecret string
 	// S3DisableSSL determines whether SSL should be used
 	S3DisableSSL bool
+	// S3DisableSSLVerify determines whether SSL certs should be verified
+	S3DisableSSLVerify bool
 	// S3Region is the S3 region
 	S3Region string
 	// AuthURL is the KBase auth server URL. It is never nil.
@@ -102,6 +108,7 @@ func New(configFilePath string) (*Config, error) {
 	s3key, err := getString(err, configFilePath, sec, KeyS3AccessKey, true)
 	s3secret, err := getString(err, configFilePath, sec, KeyS3AccessSecret, true)
 	s3disableSSL, err := getString(err, configFilePath, sec, KeyS3DisableSSL, false)
+	s3disableSSLVerify, err := getString(err, configFilePath, sec, KeyS3DisableSSLVerify, false)
 	s3region, err := getString(err, configFilePath, sec, KeyS3Region, true)
 	authurl, err := getURL(err, configFilePath, sec, KeyAuthURL)
 	roles, err := getStringList(err, configFilePath, sec, KeyAuthAdminRoles)
@@ -126,6 +133,7 @@ func New(configFilePath string) (*Config, error) {
 			S3AccessKey:         s3key,
 			S3AccessSecret:      s3secret,
 			S3DisableSSL:        "true" == s3disableSSL,
+			S3DisableSSLVerify:  "true" == s3disableSSLVerify,
 			S3Region:            s3region,
 			AuthURL:             authurl,
 			AuthAdminRoles:      roles,

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -20,7 +20,7 @@ s3-bucket = blobstore
 s3-access-key = [access key goes here]
 s3-access-secret = [access secret goes here]
 s3-region = us-west-1
-# Use plaintext to talk to destination S3.  Default false.
+# Use plaintext to talk to destination S3.  Default false. (false is not tested)
 #s3-disable-ssl = false
 # Disable verifying the destination S3 SSL cert (e.g. for self-signed certs).  Default false.
 #s3-disable-ssl-verify = false

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -21,6 +21,7 @@ s3-access-key = [access key goes here]
 s3-access-secret = [access secret goes here]
 s3-region = us-west-1
 #s3-disable-ssl = false
+#s3-disable-ssl-verify = false
 
 # KBase auth server parameters.
 # The root url of the auth server.

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -20,7 +20,9 @@ s3-bucket = blobstore
 s3-access-key = [access key goes here]
 s3-access-secret = [access secret goes here]
 s3-region = us-west-1
+# Use plaintext to talk to destination S3.  Default false.
 #s3-disable-ssl = false
+# Disable verifying the destination S3 SSL cert (e.g. for self-signed certs).  Default false.
 #s3-disable-ssl-verify = false
 
 # KBase auth server parameters.

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -33,6 +33,7 @@ type S3FileStore struct {
 	s3client    *s3.S3
 	minioClient *minio.Client
 	bucket      string
+	disableSSLverify	bool
 }
 
 // NewS3FileStore creates a new S3 based file store. Files will be stored in the provided
@@ -44,6 +45,7 @@ func NewS3FileStore(
 	s3client *s3.S3,
 	minioClient *minio.Client,
 	bucket string,
+	disableSSLverify bool,
 ) (*S3FileStore, error) {
 
 	if s3client == nil {
@@ -62,7 +64,7 @@ func NewS3FileStore(
 		// Ignore for now.
 		return nil, err
 	}
-	return &S3FileStore{s3client: s3client, minioClient: minioClient, bucket: bucket}, nil
+	return &S3FileStore{s3client: s3client, minioClient: minioClient, bucket: bucket, disableSSLverify: disableSSLverify}, nil
 }
 
 func checkBucketName(bucket string) (string, error) {

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -131,7 +131,16 @@ func (fs *S3FileStore) StoreFile(le *logrus.Entry, p *StoreFileParams) (out *Fil
 	req.Header.Set("x-amz-meta-Filename", p.filename)
 	req.Header.Set("x-amz-meta-Format", p.format)
 
-	resp, err := http.DefaultClient.Do(req)
+	// disable SSL verify if necessary
+	customTransport := &http.Transport{
+            TLSClientConfig: &tls.Config{InsecureSkipVerify: fs.disableSSLverify},
+        }
+//		  Timeout: time.Second * 10,
+	httpClient := &http.DefaultClient{
+	    Transport: customTransport,
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		// don't expose the presigned url in the returned error
 		errstr := err.(*url.Error).Err.Error()

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"crypto/tls"
 	"strconv"
 	"strings"
 	"time"

--- a/filestore/s3.go
+++ b/filestore/s3.go
@@ -137,7 +137,7 @@ func (fs *S3FileStore) StoreFile(le *logrus.Entry, p *StoreFileParams) (out *Fil
             TLSClientConfig: &tls.Config{InsecureSkipVerify: fs.disableSSLverify},
         }
 //		  Timeout: time.Second * 10,
-	httpClient := &http.DefaultClient{
+	httpClient := &http.Client{
 	    Transport: customTransport,
 	}
 

--- a/filestore/s3_test.go
+++ b/filestore/s3_test.go
@@ -83,7 +83,7 @@ func (t *TestSuite) TestConstructWithGoodBucketNames() {
 	ls := b.String()
 	t.Equal(63, len(ls), "incorrect string length")
 	for _, bucket := range []string{"foo", ls} {
-		fstore, err := NewS3FileStore(cli, min, bucket)
+		fstore, err := NewS3FileStore(cli, min, bucket, false)
 		t.NotNil(fstore, "expected filestore client")
 		t.Nil(err, "unexpected error")
 	}
@@ -123,7 +123,7 @@ func (t *TestSuite) TestConstructFailBadBucketName() {
 }
 
 func constructFail(t *TestSuite, client *s3.S3, min *minio.Client, bucket string, expected error) {
-	fstore, err := NewS3FileStore(client, min, bucket)
+	fstore, err := NewS3FileStore(client, min, bucket, false)
 	if err == nil {
 		t.FailNow("expected error")
 	}
@@ -142,7 +142,7 @@ func (t *TestSuite) TestConstructWithExistingBucket() {
 	if err != nil {
 		t.FailNow(err.Error())
 	}
-	fstore, err := NewS3FileStore(s3client, mclient, bucket)
+	fstore, err := NewS3FileStore(s3client, mclient, bucket, false)
 	if err != nil {
 		t.FailNow(err.Error())
 	}
@@ -192,7 +192,7 @@ func (t *TestSuite) storeAndGet(
 ) {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -241,7 +241,7 @@ func (t *TestSuite) storeAndGet(
 func (t *TestSuite) TestStoreWithNilInput() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	res, err := fstore.StoreFile(nil, &StoreFileParams{}) // DO NOT init SFP like this
 	t.Nil(res, "expected error")
@@ -256,7 +256,7 @@ func (t *TestSuite) TestStoreWithNilInput() {
 func (t *TestSuite) TestStoreWithIncorrectSize() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		11,
@@ -278,7 +278,7 @@ func (t *TestSuite) TestStoreWithIncorrectSize() {
 func (t *TestSuite) TestStoreFailNoBucket() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	t.minio.Clear(false)
 
@@ -308,7 +308,7 @@ func (t *TestSuite) TestStoreFailNoBucket() {
 func (t *TestSuite) TestGetWithBlankID() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	res, err := fstore.GetFile("", 0, 0)
 	if res != nil {
@@ -320,7 +320,7 @@ func (t *TestSuite) TestGetWithBlankID() {
 func (t *TestSuite) TestGetWithNonexistentID() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -344,7 +344,7 @@ func (t *TestSuite) assertNoFile(fstore FileStore, id string) {
 func (t *TestSuite) TestGetWithExcessSeek() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -372,7 +372,7 @@ func (t *TestSuite) TestGetWithoutMetaData() {
 	id := "myid"
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, bkt)
+	fstore, _ := NewS3FileStore(s3client, mclient, bkt, false)
 
 	_, err := s3client.PutObject(&s3.PutObjectInput{
 		Bucket: &bkt,
@@ -414,7 +414,7 @@ func (t *TestSuite) TestGetWithoutMetaData() {
 func (t *TestSuite) TestDeleteObject() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -434,7 +434,7 @@ func (t *TestSuite) TestDeleteObject() {
 func (t *TestSuite) TestDeleteObjectWrongID() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -460,7 +460,7 @@ func (t *TestSuite) TestDeleteObjectWrongID() {
 func (t *TestSuite) TestDeleteWithBlankID() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	err := fstore.DeleteFile("")
 	t.Equal(errors.New("id cannot be empty or whitespace only"), err, "incorrect err")
@@ -469,7 +469,7 @@ func (t *TestSuite) TestDeleteWithBlankID() {
 func (t *TestSuite) TestDeleteFailNoBucket() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	t.minio.Clear(false)
 
@@ -493,7 +493,7 @@ func (t *TestSuite) copy(
 	format string) {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		srcobj,
 		12,
@@ -544,7 +544,7 @@ func (t *TestSuite) copy(
 func (t *TestSuite) TestCopyBadInput() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 
 	t.copyFail(fstore, "  \t  \n  ", "bar",
 		errors.New("sourceID cannot be empty or whitespace only"))
@@ -566,7 +566,7 @@ func (t *TestSuite) copyFail(fstore FileStore, src string, dst string, expected 
 func (t *TestSuite) TestCopyNonExistentFile() {
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams(
 		"myid",
 		12,
@@ -594,7 +594,7 @@ func (t *TestSuite) testCopyLargeObject() {
 	}
 	s3client := t.minio.CreateS3Client()
 	mclient, _ := t.minio.CreateMinioClient()
-	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket")
+	fstore, _ := NewS3FileStore(s3client, mclient, "mybucket", false)
 	p, _ := NewStoreFileParams("myid", fi.Size(), reader)
 	start := time.Now()
 	obj, err := fstore.StoreFile(logrus.WithField("a", "b"), p)

--- a/service/build.go
+++ b/service/build.go
@@ -76,7 +76,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 	minioClient, err := minio.NewWithRegion(
 		cfg.S3Host,
 		&minio.Options{
-			Creds: credentialsNewStaticV4(cfg.S3AccessKey, cfg.S3AccessSecret, ""),
+			Creds: creds,
 			Secure: !cfg.S3DisableSSL,
 			Region: cfg.S3Region,
 			Transport: customTransport,

--- a/service/build.go
+++ b/service/build.go
@@ -83,7 +83,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return filestore.NewS3FileStore(awscli, minioClient, cfg.S3Bucket)
+	return filestore.NewS3FileStore(awscli, minioClient, cfg.S3Bucket, cfg.S3DisableSSLVerify)
 }
 
 func buildNodeStore(cfg *config.Config) (nodestore.NodeStore, error) {

--- a/service/build.go
+++ b/service/build.go
@@ -64,7 +64,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 
 	// need a custom transport to support not verifying SSL cert
 	customTransport := &http.Transport{
-	    TLSClientConfig: &tls.Config{InsecureSkipVerify: &cfg.S3DisableSSLVerify},
+	    TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.S3DisableSSLVerify},
         }
 
 	awscli := s3.New(sess, &aws.Config{

--- a/service/build.go
+++ b/service/build.go
@@ -23,7 +23,6 @@ import (
 	authcache "github.com/kbase/blobstore/auth/cache"
 	"github.com/kbase/blobstore/config"
 	"github.com/minio/minio-go"
-	"github.com/minio/minio-go/pkg/credentials"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -64,7 +63,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 
 	// need a custom transport to support not verifying SSL cert
 	customTransport := &http.Transport{
-	    TLSClientConfig: &tls.Config{InsecureSkipVerify: &cfg.S3DisableSSLVerify}
+	    TLSClientConfig: &tls.Config{InsecureSkipVerify: &cfg.S3DisableSSLVerify},
         }
 
 	awscli := s3.New(sess, &aws.Config{
@@ -80,7 +79,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 			Creds: credentialsNewStaticV4(cfg.S3AccessKey, cfg.S3AccessSecret, ""),
 			Secure: !cfg.S3DisableSSL,
 			Region: cfg.S3Region,
-			Transport: customTransport
+			Transport: customTransport,
 		} )
 	
 	if err != nil {

--- a/service/build.go
+++ b/service/build.go
@@ -73,7 +73,7 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 		Endpoint:         &cfg.S3Host,
 		Region:           &cfg.S3Region,
 		DisableSSL:       &cfg.S3DisableSSL,
-		HTTPClient: customHTTPClient,
+		HTTPClient:       customHTTPClient,
 		S3ForcePathStyle: &trueref}) // minio pukes otherwise
 
 	minioClient, err := minio.NewWithRegion(

--- a/service/build.go
+++ b/service/build.go
@@ -74,13 +74,8 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 		S3ForcePathStyle: &trueref}) // minio pukes otherwise
 
 	minioClient, err := minio.NewWithRegion(
-		cfg.S3Host,
-		&minio.Options{
-			Creds: creds,
-			Secure: !cfg.S3DisableSSL,
-			Region: cfg.S3Region,
-			Transport: customTransport,
-		} )
+		cfg.S3Host, cfg.S3AccessKey, cfg.S3AccessSecret, !cfg.S3DisableSSL, cfg.S3Region)
+        minioClient.SetCustomTransport(customTransport)
 	
 	if err != nil {
 		return nil, err

--- a/service/build.go
+++ b/service/build.go
@@ -66,12 +66,14 @@ func buildFileStore(cfg *config.Config) (filestore.FileStore, error) {
 	customTransport := &http.Transport{
 	    TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.S3DisableSSLVerify},
         }
+	customHTTPClient := &http.Client{Transport: customTransport}
 
 	awscli := s3.New(sess, &aws.Config{
 		Credentials:      creds,
 		Endpoint:         &cfg.S3Host,
 		Region:           &cfg.S3Region,
 		DisableSSL:       &cfg.S3DisableSSL,
+		HTTPClient: customHTTPClient,
 		S3ForcePathStyle: &trueref}) // minio pukes otherwise
 
 	minioClient, err := minio.NewWithRegion(

--- a/service/build.go
+++ b/service/build.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"crypto/tls"
 
 	"github.com/aws/aws-sdk-go/service/s3"
 


### PR DESCRIPTION
Add a configuration option (default to false) that disables verification of the S3 SSL certificate (for example, if it is self-signed).

- [x] Add support for s3-disable-ssl-verify flag (default false)
- [x] Have minioClient constructor honor new flag
- [x] Have awscli constructor honor new flag
- [x] Have http.NewRequest honor new flag (will need to add option to NewS3FileStore constructor)
- [ ] Add tests for self-signed cert flag
- [ ] Test against a minio with a self-signed cert in a deploy env
- [ ] Update version, documentation and release notes
