### PR TITLE
Add query param to delete after file stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ RETURNS: an ACL.
 ## Download a file from a node
 ```
 AUTHORIZATION OPTIONAL
-GET /node/<id>?download[_raw][&seek=#][&length=#]
+GET /node/<id>?download[_raw][&seek=#][&length=#][&del]
 
 RETURNS: the file content.
 ```
@@ -185,6 +185,10 @@ to the file size is an error. Defaults to 0.
 `length` determines the number of bytes of the file to return after skipping `seek` bytes.
 `length` may be greater than the remaining file length. Defaults to 0, which indicates that the
 remainder of the file should be returned.
+
+`del` causes the node to be deleted once the file contents have been streamed. The user must
+be the node owner or a service administrator. Note this is playing very fast and loose with the
+semantics of an HTTP GET.
 
 ## Set a node to be publicly readable
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,22 @@
+# 0.1.4
+
+* Added the `del` param when downloading the file from a node.
+
 # 0.1.3
 
-- Added GHA workflows and removed Travis CI
-- MongoController is now compatible with Mongo versions 2 through 7
-- Updated test config file to specify the auth2 shadow jar path vs. the jars repo path
+* Added GHA workflows and removed Travis CI
+* MongoController is now compatible with Mongo versions 2 through 7
+* Updated test config file to specify the auth2 shadow jar path vs. the jars repo path
 
 # 0.1.2
 
-- Support for disabling SSL verification of remote S3 certificates (default false) with the s3-disable-ssl-verify option in the configuration file.
+* Support for disabling SSL verification of remote S3 certificates (default false)
+  with the s3-disable-ssl-verify option in the configuration file.
 
 # 0.1.1
 
-- Added seek & length parameters to file download requests
+* Added seek & length parameters to file download requests
 
 # 0.1.0
 
-- Initial release
+* Initial release

--- a/service/errortypes.go
+++ b/service/errortypes.go
@@ -14,6 +14,20 @@ const (
 	invalidAuthHeader = "Invalid authorization header or content"
 )
 
+// UnauthorizedCustomError denotes that an unauthorized operation was requested that needs
+// special explanation in the error string.
+type UnauthorizedCustomError string
+
+// UnauthorizedCustomError creates a new UnauthorizedCustomError.
+func NewUnauthorizedCustomError(err string) *UnauthorizedCustomError {
+	e := UnauthorizedCustomError(err)
+	return &e
+}
+
+func (e *UnauthorizedCustomError) Error() string {
+	return string(*e)
+}
+
 func translateError(err error) (code int, errstr string) {
 	// not sure about this approach. Alternative is to add some state to every error that
 	// can be mapped to a code, and I'm not super thrilled about that either.
@@ -30,6 +44,8 @@ func translateError(err error) (code int, errstr string) {
 		// Shock compatibility, really should be 403 forbidden
 		return http.StatusBadRequest, "Users that are not node owners can only delete " +
 			"themselves from ACLs."
+	case *UnauthorizedCustomError:
+		return http.StatusUnauthorized, t.Error()
 	case *auth.InvalidUserError:
 		// no equivalent shock error, it accepts any string as a username
 		return http.StatusBadRequest, t.Error()

--- a/service/server.go
+++ b/service/server.go
@@ -514,6 +514,11 @@ func (s *Server) getNode(w http.ResponseWriter, r *http.Request) {
 	user := getUser(r)
 	download := download(r.URL)
 	if download != "" {
+		del, err := checkDel(s, user, id, r.URL)
+		if err != nil {
+			writeError(le, err, w)
+			return
+		}
 		seek, length, err := getSeekAndLengthFromQuery(r.URL)
 		if err != nil {
 			writeError(le, err, w)
@@ -534,6 +539,9 @@ func (s *Server) getNode(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-length", strconv.FormatInt(size, 10))
 		w.Header().Set("content-type", "application/octet-stream")
 		io.Copy(w, datareader)
+		if del {
+			s.store.DeleteNode(*user, *id) // ignore errors since file is written to output
+		}
 	} else {
 		node, err := s.store.Get(user, *id)
 		if err != nil {
@@ -542,6 +550,29 @@ func (s *Server) getNode(w http.ResponseWriter, r *http.Request) {
 		}
 		writeNode(w, node)
 	}
+}
+
+func checkDel(s *Server, user *auth.User, id *uuid.UUID, u *url.URL) (del bool, err error) {
+	delete := false
+	if _, ok := u.Query()["del"]; ok {
+		delete = true
+		// If we want to move the deletion into the core logic it could go like this:
+		// * pass in deletion flag and a pre-write function that accepts a node
+		// * do the ACL checks, etc.
+		// * the pre-write function is called, which writes the headers to the writer
+		//   * the core logic should not know the writer is a http.ResponseWriter
+		// * stream the file
+		// * delete the node
+		// not worth the trouble for now
+		node, err := s.store.Get(user, *id)
+		if err != nil {
+			return false, err
+		}
+		if user == nil || (user.GetUserName() != node.Owner.AccountName && !user.IsAdmin()) {
+			return false, NewUnauthorizedCustomError("Only node owners can delete nodes")
+		}
+	}
+	return delete, nil
 }
 
 func getSeekAndLengthFromQuery(u *url.URL) (uint64, uint64, error) {


### PR DESCRIPTION
This is useful for temporary nodes where once the user has the data, the node is no longer needed, and the link to the data is expected to work once.