### PR TITLE
Restrict filename and format strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ curl -H "Authorization: OAuth $KBASE_TOKEN" -T mylittlefile
   "http://<host>/node?filename=mylittlefile&format=text"
 ```
 
-`filename` can be at most 256 characters with no control characters.  
-`format` can be at most 100 characters with no control characters.
+`filename` can be at most 256 characters consisting of only unicode alphanumerics, space, and
+the characters `[ ] ( ) = . - _`.  
+`format` can be at most 100 characters consisting of only unicode alphanumerics and
+the characters `- _`. 
 
 ## Copy a node
 ```
@@ -265,8 +267,8 @@ The form **may** contain a part called `format` where the part contents are the 
 file, equivalent to the `format` query parameter for the standard upload method and with the same
 restrictions. The `format` part **MUST** come before the `upload` part.
 
-Any file name provided in the `Content-Disposition` header can be at most 256 characters with no
-control characters.
+Any file name provided in the `Content-Disposition` header has the same restrictions as the
+filename parameter for the standard upload method.
 
 ### Curl example
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@
 
 * Added the `del` param when downloading the file from a node.
 * The Blobstore will now look for auth tokens in cookies specified in the deployment configuration.
+* The filename and format strings are now much more restrictive in regard to allowed contents.
+  See the API documenation for details.
+  * Any extant data is not affected and will be returned when requested as normal.
 
 # 0.1.3
 

--- a/core/values/values_test.go
+++ b/core/values/values_test.go
@@ -51,7 +51,7 @@ func TestFileName(t *testing.T) {
 }
 
 func fileNameString() string {
-	s := "ab9 8&#']K[1*(&)ꢇ]" // 20 bytes
+	s := "ab9_8४.[]( )1=-ꢇ" // 20 bytes
 
 	b := strings.Builder{}
 	for i := 0; i < 12; i++ {
@@ -72,18 +72,34 @@ func TestFileNameFail(t *testing.T) {
 	assert.Nil(t, fn, "expected error")
 	assert.Equal(t, NewIllegalInputError("File name contains control characters"), err,
 		"incorrect error")
+	for _, ch := range []string{"*", ":", "?", "|", "✈", "🐱", "∞", "€", "◊"} {
+		fn, err = NewFileName("abc"+ch+"neg")
+		assert.Nil(t, fn, "expected error")
+		errstr := "File name string abc"+ch+"neg contains an illegal character: '"+ch+"'"
+		assert.Equal(t, NewIllegalInputError(errstr), err, "incorrect error")
+	}
 }
 
 func TestFileFormat(t *testing.T) {
-	fns := fileNameString()[:100]
+	fns := formatString()
 	assert.Equal(t, 100, len(fns), "incorrect length")
 	fn, err := NewFileFormat("    \t       " + fns + "    \t       ")
 	assert.Nil(t, err, "unexpected error")
 	assert.Equal(t, fns, fn.GetFileFormat())
 }
 
+func formatString() string {
+	s := "ab9_8४K3Z23o1n-ꢇ" // 20 bytes
+
+	b := strings.Builder{}
+	for i := 0; i < 5; i++ {
+		b.Write([]byte(s))
+	}
+	return b.String()
+}
+
 func TestFileFormatFail(t *testing.T) {
-	fns := fileNameString()[:100]
+	fns := formatString()
 	assert.Equal(t, 100, len(fns), "incorrect length")
 	fn, err := NewFileFormat(fns + "a")
 	assert.Nil(t, fn, "expected error")
@@ -93,4 +109,11 @@ func TestFileFormatFail(t *testing.T) {
 	assert.Nil(t, fn, "expected error")
 	assert.Equal(t, NewIllegalInputError("File format contains control characters"), err,
 		"incorrect error")
+	badchrs := []string{"*", ":", "?", "|", "✈", "🐱", "∞", "€", "◊", "=", "[", "]", "(", ")", "."}
+	for _, ch := range badchrs {
+		fn, err = NewFileFormat("abc"+ch+"neg")
+		assert.Nil(t, fn, "expected error")
+		errstr := "File format string abc"+ch+"neg contains an illegal character: '"+ch+"'"
+		assert.Equal(t, NewIllegalInputError(errstr), err, "incorrect error")
+	}
 }


### PR DESCRIPTION
... to a reasonable character set. This avoids characters that may cause issues in mac, linux, and windows