### PR TITLE
DEVOPS-1990 Update to go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as build
+FROM golang:1.16.15-alpine3.15 as build
 
 # git is not included, weirdly, so nothing with ext deps can build
 RUN apk add git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-alpine3.9 as build
+FROM golang:1.16-alpine as build
 
 # git is not included, weirdly, so nothing with ext deps can build
 RUN apk add git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kbase/blobstore
 
-go 1.12
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.19.21


### PR DESCRIPTION

* Attempt to fix crash from http request
```
{"log":"panic: runtime error: slice bounds out of range\r\n","stream":"stdout","time":"2024-07-26T22:32:50.680661674Z"}
```

from
```
This is where it's happening https://github.com/kbase/blobstore/blob/1cc0178ee0a3814aef917b5d4882d52565911494/filestore/s3.go#L151

[s3.go](https://github.com/kbase/blobstore/blob/1cc0178ee0a3814aef917b5d4882d52565911494/filestore/s3.go)
        return nil, errors.New("s3 store request: " + errstr)
```
Attempted solution is to upgrade the httplib